### PR TITLE
refactor: task manager and invidual tasks

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,6 +18,7 @@ use screeps::{
 use wasm_bindgen::prelude::*;
 
 mod logging;
+mod tasks;
 
 // add wasm_bindgen to any function you would like to expose for call from js
 #[wasm_bindgen]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,21 +1,19 @@
 use std::cell::RefCell;
-use std::collections::{hash_map::Entry, HashMap};
-use std::fmt::Debug;
+use std::collections::hash_map::Entry;
 
 use log::*;
 use screeps::{
-    constants::{ErrorCode, Part, ResourceType},
+    constants::{Part, ResourceType},
     enums::StructureObject,
     find, game,
-    local::ObjectId,
-    objects::{Creep, Source, StructureController},
+    objects::Creep,
     prelude::*,
 };
-use screeps::{
-    ConstructionSite, Room, RoomObjectProperties, Structure, StructureExtension, StructureSpawn,
-    StructureTower, StructureType,
-};
+use screeps::{Room, RoomObjectProperties, StructureType};
+use tasks::{HarvestTask, Task, TaskManager, TransferTask};
 use wasm_bindgen::prelude::*;
+
+use crate::tasks::{BuildTask, RepairTask, UpgradeTask};
 
 mod logging;
 mod tasks;
@@ -29,84 +27,13 @@ pub fn setup() {
 // this is one way to persist data between ticks within Rust's memory, as opposed to
 // keeping state in memory on game objects - but will be lost on global resets!
 thread_local! {
-    static CREEP_TARGETS: RefCell<HashMap<String, CreepTarget>> = RefCell::new(HashMap::new());
-}
-
-// this enum will represent a creep's lock on a specific target object, storing a js reference
-// to the object id so that we can grab a fresh reference to the object each successive tick,
-// since screeps game objects become 'stale' and shouldn't be used beyond the tick they were fetched
-#[derive(Clone)]
-enum CreepTarget {
-    Upgrade(ObjectId<StructureController>),
-    Harvest(ObjectId<Source>),
-    Build(ObjectId<ConstructionSite>),
-    TransferToSpawn(ObjectId<StructureSpawn>),
-    TransferToExtension(ObjectId<StructureExtension>),
-    TransferToTower(ObjectId<StructureTower>),
-    Heal(ObjectId<Creep>),
-    Repair(ObjectId<Structure>),
-}
-
-impl Debug for CreepTarget {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            CreepTarget::Upgrade(id) => write!(f, "Upgrade({:?})", id),
-            CreepTarget::Harvest(id) => {
-                if let Some(source) = id.resolve() {
-                    write!(
-                        f,
-                        "Harvest at ({}, {}) [{}/{}]",
-                        source.pos().x().u8(),
-                        source.pos().y().u8(),
-                        source.energy(),
-                        source.energy_capacity()
-                    )
-                } else {
-                    write!(f, "Harvest ({:?})", id)
-                }
-            }
-            CreepTarget::Build(id) => {
-                if let Some(construction_site) = id.resolve() {
-                    write!(
-                        f,
-                        "Build {:?} at ({}, {}) [{}/{}]",
-                        construction_site.structure_type(),
-                        construction_site.pos().x().u8(),
-                        construction_site.pos().y().u8(),
-                        construction_site.progress(),
-                        construction_site.progress_total()
-                    )
-                } else {
-                    write!(f, "Build ({:?})", id)
-                }
-            }
-            CreepTarget::TransferToSpawn(id) => write!(f, "TransferToSpawn({:?})", id),
-            CreepTarget::TransferToExtension(id) => write!(f, "TransferToExtension({:?})", id),
-            CreepTarget::TransferToTower(id) => write!(f, "TransferToTower({:?})", id),
-            CreepTarget::Heal(id) => write!(f, "Heal({:?})", id),
-            CreepTarget::Repair(id) => {
-                if let Some(structure) = id.resolve() {
-                    write!(
-                        f,
-                        "Repair {:?} at ({}, {}) [{}/{}]",
-                        structure.structure_type(),
-                        structure.pos().x().u8(),
-                        structure.pos().y().u8(),
-                        structure.hits(),
-                        structure.hits_max()
-                    )
-                } else {
-                    write!(f, "Repair ({:?})", id)
-                }
-            }
-        }
-    }
+    static TASK_MANAGER: RefCell<TaskManager> = RefCell::new(TaskManager::new());
 }
 
 // to use a reserved name as a function name, use `js_name`:
 #[wasm_bindgen(js_name = loop)]
 pub fn game_loop() {
-    let target_creep_count = 7;
+    let target_creep_count = 5;
 
     debug!(
         "loop starting! CPU: {}. Peak Malloc: {}. Total Memory: {}",
@@ -114,25 +41,28 @@ pub fn game_loop() {
         game::cpu::get_heap_statistics().peak_malloced_memory(),
         game::cpu::get_heap_statistics().total_heap_size()
     );
-    // mutably borrow the creep_targets refcell, which is holding our creep target locks
+    // mutably borrow the task_manager refcell, which is holding our creep target locks
     // in the wasm heap
-    CREEP_TARGETS.with(|creep_targets_refcell| {
-        let mut creep_targets = creep_targets_refcell.borrow_mut();
+    TASK_MANAGER.with(|task_manager_refcell| {
+        let mut task_manager = task_manager_refcell.borrow_mut();
         debug!("running creeps");
 
         let creeps = game::creeps().values();
         let idle_creeps = creeps
-            .filter(|c| match creep_targets.entry(c.name()) {
+            .filter(|c| match task_manager.tasks.entry(c.try_id().unwrap()) {
                 Entry::Occupied(_) => false,
                 Entry::Vacant(_) => true,
             })
             .collect::<Vec<Creep>>();
         let idle_creep_count = idle_creeps.len();
 
-        let mut jobs = Vec::new();
+        let mut tasks = Vec::new();
         if let Some(creep) = idle_creeps.get(0) {
-            jobs =
-                get_creep_target_jobs(&creep.room().unwrap(), idle_creep_count, target_creep_count);
+            tasks = get_potential_creep_tasks(
+                &creep.room().unwrap(),
+                idle_creep_count,
+                target_creep_count,
+            );
         }
 
         for creep in idle_creeps {
@@ -144,33 +74,41 @@ pub fn game_loop() {
                     .find(find::SOURCES_ACTIVE, None)
                     .get(0)
                 {
-                    let job = CreepTarget::Harvest(source.id());
+                    let task = HarvestTask::new(source.id());
                     let _ = js_sys::Reflect::set(
                         &creep.memory(),
-                        &JsValue::from_str("job"),
-                        &JsValue::from_str(&format!("{:?}", job)),
+                        &JsValue::from_str("task"),
+                        &JsValue::from_str(&format!("{:?}", task)),
                     );
-                    creep_targets.insert(creep.name(), job);
+                    task_manager.add_task(&creep, Box::new(task));
                     return;
                 }
             }
 
-            // Once they have enough energy, they can pick up a job
-            let job = jobs.pop();
-            if let Some(job) = job {
-                info!("assigning {} to {:?}", creep.name(), job);
+            // Once they have enough energy, they can pick up a task
+            let task = tasks.pop();
+            if let Some(task) = task {
+                info!("assigning {} to {:?}", creep.name(), task);
                 let _ = js_sys::Reflect::set(
                     &creep.memory(),
-                    &JsValue::from_str("job"),
-                    &JsValue::from_str(&format!("{:?}", job)),
+                    &JsValue::from_str("task"),
+                    &JsValue::from_str(&format!("{:?}", task)),
                 );
-                creep_targets.insert(creep.name(), job);
+                task_manager.add_task(&creep, task);
+            } else {
+                let task = UpgradeTask::new(creep.room().unwrap().controller().unwrap().id());
+                info!("[DEFAULT] assigning {} to {:?}", creep.name(), task);
+
+                let _ = js_sys::Reflect::set(
+                    &creep.memory(),
+                    &JsValue::from_str("task"),
+                    &JsValue::from_str(&format!("{:?}", task)),
+                );
+                task_manager.add_task(&creep, Box::new(task));
             }
         }
 
-        for creep in game::creeps().values() {
-            run_creep(&creep, &mut creep_targets);
-        }
+        task_manager.execute_tasks();
     });
 
     spawn_creeps(target_creep_count);
@@ -209,7 +147,7 @@ fn spawn_creeps(target_creep_count: usize) {
 
         info!("base body cost: {}", base_cost);
 
-        if (spawn.room().unwrap().energy_available() > base_cost) {
+        if spawn.room().unwrap().energy_available() > base_cost {
             let remaining_energy =
                 std::cmp::max(spawn.room().unwrap().energy_available() - base_cost, 0);
             let x = Part::Move.cost() + Part::Work.cost() + 1;
@@ -241,12 +179,12 @@ fn spawn_creeps(target_creep_count: usize) {
     }
 }
 
-fn get_creep_target_jobs(
+fn get_potential_creep_tasks(
     room: &Room,
-    max_jobs: usize,
+    max_tasks: usize,
     target_creep_count: usize,
-) -> Vec<CreepTarget> {
-    let mut creep_targets: Vec<CreepTarget> = Vec::new();
+) -> Vec<Box<dyn Task>> {
+    let mut creep_targets: Vec<Box<dyn Task>> = Vec::new();
 
     let structures = room.find(find::STRUCTURES, None);
     let construction_sites = room.find(find::CONSTRUCTION_SITES, None);
@@ -256,8 +194,8 @@ fn get_creep_target_jobs(
     if let Some(c) = controller {
         if let Some(owner) = c.owner() {
             if owner.username() == "CrazyFluff" && c.ticks_to_downgrade() < 10000 && c.is_active() {
-                creep_targets.push(CreepTarget::Upgrade(c.id()));
-                if creep_targets.len() >= max_jobs {
+                creep_targets.push(Box::new(UpgradeTask::new(c.id())));
+                if creep_targets.len() >= max_tasks {
                     return creep_targets;
                 }
             }
@@ -268,15 +206,15 @@ fn get_creep_target_jobs(
     if let Some(spawn) = room.find(find::MY_SPAWNS, None).get(0) {
         if spawn.is_active() && spawn.store().get_free_capacity(Some(ResourceType::Energy)) > 0 {
             if let Some(id) = spawn.try_id() {
-                creep_targets.push(CreepTarget::TransferToSpawn(id));
+                creep_targets.push(Box::new(TransferTask::new(id)));
 
                 if game::creeps().values().count() < target_creep_count {
-                    for _ in 0..max_jobs {
-                        creep_targets.push(CreepTarget::TransferToSpawn(id));
+                    for _ in 0..max_tasks {
+                        creep_targets.push(Box::new(TransferTask::new(id)));
                     }
                 }
 
-                if creep_targets.len() >= max_jobs {
+                if creep_targets.len() >= max_tasks {
                     return creep_targets;
                 }
             }
@@ -292,8 +230,8 @@ fn get_creep_target_jobs(
             if tower.is_active() && tower.store().get_free_capacity(Some(ResourceType::Energy)) > 0
             {
                 if let Some(id) = tower.try_id() {
-                    creep_targets.push(CreepTarget::TransferToTower(id));
-                    if creep_targets.len() >= max_jobs {
+                    creep_targets.push(Box::new(TransferTask::new(id)));
+                    if creep_targets.len() >= max_tasks {
                         return creep_targets;
                     }
                 }
@@ -314,15 +252,15 @@ fn get_creep_target_jobs(
                     > 0
             {
                 if let Some(id) = extension.try_id() {
-                    creep_targets.push(CreepTarget::TransferToExtension(id));
+                    creep_targets.push(Box::new(TransferTask::new(id)));
 
                     if game::creeps().values().count() < target_creep_count {
-                        for _ in 0..max_jobs {
-                            creep_targets.push(CreepTarget::TransferToExtension(id));
+                        for _ in 0..max_tasks {
+                            creep_targets.push(Box::new(TransferTask::new(id)));
                         }
                     }
 
-                    if creep_targets.len() >= max_jobs {
+                    if creep_targets.len() >= max_tasks {
                         return creep_targets;
                     }
                 }
@@ -355,8 +293,8 @@ fn get_creep_target_jobs(
                 }
             }
             let id = s.try_id().unwrap();
-            creep_targets.push(CreepTarget::Repair(id));
-            if creep_targets.len() >= max_jobs {
+            creep_targets.push(Box::new(RepairTask::new(id)));
+            if creep_targets.len() >= max_tasks {
                 return creep_targets;
             }
         }
@@ -365,8 +303,8 @@ fn get_creep_target_jobs(
     // construction sites
     for construction_site in construction_sites.iter() {
         if let Some(id) = construction_site.try_id() {
-            creep_targets.push(CreepTarget::Build(id));
-            if creep_targets.len() >= max_jobs {
+            creep_targets.push(Box::new(BuildTask::new(id)));
+            if creep_targets.len() >= max_tasks {
                 return creep_targets;
             }
         }
@@ -375,184 +313,4 @@ fn get_creep_target_jobs(
     info!("creep targets: {:?}", creep_targets.len());
 
     creep_targets
-}
-
-fn run_creep(creep: &Creep, creep_targets: &mut HashMap<String, CreepTarget>) {
-    if creep.spawning() {
-        return;
-    }
-
-    let name = creep.name();
-    let target = creep_targets.entry(name);
-    match target {
-        Entry::Occupied(entry) => {
-            let creep_target = entry.get();
-            match creep_target {
-                CreepTarget::Upgrade(controller_id)
-                    if creep.store().get_used_capacity(Some(ResourceType::Energy)) > 0 =>
-                {
-                    if let Some(controller) = controller_id.resolve() {
-                        creep
-                            .upgrade_controller(&controller)
-                            .unwrap_or_else(|e| match e {
-                                ErrorCode::NotInRange => {
-                                    let _ = creep.move_to(&controller);
-                                }
-                                _ => {
-                                    warn!("couldn't upgrade: {:?}", e);
-                                    entry.remove();
-                                }
-                            });
-                    } else {
-                        entry.remove();
-                    }
-                }
-                CreepTarget::Build(construction_site_id)
-                    if creep.store().get_used_capacity(Some(ResourceType::Energy)) > 0 =>
-                {
-                    if let Some(construction_site) = construction_site_id.resolve() {
-                        creep.build(&construction_site).unwrap_or_else(|e| match e {
-                            ErrorCode::NotInRange => {
-                                let _ = creep.move_to(&construction_site);
-                            }
-                            _ => {
-                                warn!("couldn't build: {:?}", e);
-                                entry.remove();
-                            }
-                        });
-                    } else {
-                        entry.remove();
-                    }
-                }
-                CreepTarget::Harvest(source_id)
-                    if creep.store().get_free_capacity(Some(ResourceType::Energy)) > 0 =>
-                {
-                    if let Some(source) = source_id.resolve() {
-                        if creep.pos().is_near_to(source.pos()) {
-                            creep.harvest(&source).unwrap_or_else(|e| {
-                                warn!("couldn't harvest: {:?}", e);
-                                entry.remove();
-                            });
-                        } else {
-                            let _ = creep.move_to(&source);
-                        }
-                    } else {
-                        entry.remove();
-                    }
-                }
-                CreepTarget::TransferToSpawn(source_id)
-                    if creep.store().get_used_capacity(Some(ResourceType::Energy)) > 0 =>
-                {
-                    if let Some(source) = source_id.resolve() {
-                        if creep.pos().is_near_to(source.pos()) {
-                            creep
-                                .transfer(&source, ResourceType::Energy, None)
-                                .unwrap_or_else(|e| {
-                                    warn!("couldn't transfer to spawn: {:?}", e);
-                                    entry.remove();
-                                });
-                        } else {
-                            let _ = creep.move_to(&source);
-                        }
-                    } else {
-                        entry.remove();
-                    }
-                }
-                CreepTarget::TransferToExtension(source_id)
-                    if creep.store().get_used_capacity(Some(ResourceType::Energy)) > 0 =>
-                {
-                    if let Some(source) = source_id.resolve() {
-                        if creep.pos().is_near_to(source.pos()) {
-                            creep
-                                .transfer(&source, ResourceType::Energy, None)
-                                .unwrap_or_else(|e| {
-                                    warn!("couldn't transfer to extension: {:?}", e);
-                                    entry.remove();
-                                });
-                        } else {
-                            let _ = creep.move_to(&source);
-                        }
-                    } else {
-                        entry.remove();
-                    }
-                }
-                CreepTarget::TransferToTower(source_id)
-                    if creep.store().get_used_capacity(Some(ResourceType::Energy)) > 0 =>
-                {
-                    if let Some(source) = source_id.resolve() {
-                        if creep.pos().is_near_to(source.pos()) {
-                            creep
-                                .transfer(&source, ResourceType::Energy, None)
-                                .unwrap_or_else(|e| {
-                                    warn!("couldn't transfer to tower: {:?}", e);
-                                    entry.remove();
-                                });
-                        } else {
-                            let _ = creep.move_to(&source);
-                        }
-                    } else {
-                        entry.remove();
-                    }
-                }
-                CreepTarget::Heal(creep_id) => {
-                    if let Some(creep2) = creep_id.resolve() {
-                        if creep2.hits() < creep2.hits_max() {
-                            if creep.pos().is_near_to(creep2.pos()) {
-                                creep.heal(&creep2).unwrap_or_else(|e| {
-                                    warn!("couldn't heal: {:?}", e);
-                                });
-                                entry.remove();
-                            } else {
-                                let _ = creep.move_to(&creep2);
-                            }
-                        } else {
-                            entry.remove();
-                        }
-                    } else {
-                        entry.remove();
-                    }
-                }
-                CreepTarget::Repair(structure_id)
-                    if creep.store().get_used_capacity(Some(ResourceType::Energy)) > 0 =>
-                {
-                    if let Some(structure) = structure_id.resolve() {
-                        if creep.pos().is_near_to(structure.pos()) {
-                            creep.repair(&structure).unwrap_or_else(|e| {
-                                warn!("couldn't repair: {:?}", e);
-                            });
-                            // info!(
-                            //     "{} repairing {} ({:?})",
-                            //     creep.name(),
-                            //     structure.id(),
-                            //     structure.structure_type()
-                            // );
-                            if (structure.hits() >= structure.hits_max()
-                                || creep.store().get_used_capacity(Some(ResourceType::Energy)) == 0)
-                            {
-                                entry.remove();
-                            }
-                        } else {
-                            let _ = creep.move_to(&structure);
-                        }
-                    } else {
-                        entry.remove();
-                    }
-                }
-                _ => {
-                    entry.remove();
-                }
-            };
-        }
-        Entry::Vacant(entry) => {
-            // no target, let's find one depending on if we have energy
-            let room = creep.room().expect("couldn't resolve creep room");
-            if creep.store().get_used_capacity(Some(ResourceType::Energy)) > 0 {
-                if let Some(controller) = room.controller() {
-                    entry.insert(CreepTarget::Upgrade(controller.id()));
-                }
-            } else {
-                error!("creep {} has no target and no energy", creep.name());
-            }
-        }
-    }
 }

--- a/src/tasks.rs
+++ b/src/tasks.rs
@@ -1,0 +1,81 @@
+use std::{hash::Hash, collections::HashMap, sync::Arc, rc::Rc, cell::RefCell};
+
+use screeps::{Creep, ObjectId, HasPosition, SharedCreepProperties, game, MaybeHasTypedId};
+use log::*;
+
+pub struct TaskManager {
+    pub tasks: HashMap<ObjectId<Creep>, Box<dyn Task>>,
+}
+
+impl TaskManager {
+    fn new() -> TaskManager {
+        TaskManager {
+            tasks: HashMap::new(),
+        }
+    }
+
+    pub fn add_task(&mut self, creep: &Creep, task: Box<dyn Task>) {
+        self.tasks.insert(creep.try_id().unwrap(), task);
+    }
+
+    pub fn execute_tasks(&mut self) {
+        let completed_tasks = Rc::new(RefCell::new(Vec::new()));
+        let cancelled_tasks = Rc::new(RefCell::new(Vec::new()));
+        for (creep_id, task) in self.tasks.iter() {
+            if let Some(creep) = game::get_object_by_id_typed(creep_id) {
+                let completed_tasks_clone = completed_tasks.clone();
+                let cancelled_tasks_clone = cancelled_tasks.clone();
+                task.execute(&creep,
+                     Box::new(move |creep_id| completed_tasks_clone.borrow_mut().push(creep_id)),
+                     Box::new(move |creep_id| cancelled_tasks_clone.borrow_mut().push(creep_id))
+                    );
+            }
+        }
+        for completed_task in completed_tasks.borrow().iter() {
+            info!("task completed: {:?}", completed_task);
+            self.tasks.remove(&completed_task);
+        }
+        for cancelled_task in cancelled_tasks.borrow().iter() {
+            info!("task cancelled: {:?}", cancelled_task);
+            self.tasks.remove(&cancelled_task);
+        }
+    }
+}
+
+trait Task {
+    fn execute(&self, creep: &Creep, complete: Box<dyn FnOnce(ObjectId<Creep>)>, cancel: Box<dyn FnOnce(ObjectId<Creep>)>);
+}
+
+struct HealTask {
+    target: ObjectId<Creep>,
+}
+
+impl HealTask {
+    fn new(target: ObjectId<Creep>) -> HealTask {
+        HealTask {
+            target,
+        }
+    }
+}
+
+impl Task for HealTask {
+    fn execute(&self, creep: &Creep, complete: Box<dyn FnOnce(ObjectId<Creep>)>, cancel: Box<dyn FnOnce(ObjectId<Creep>)>) {
+        if let Some(target_creep) = self.target.resolve() {
+            if target_creep.hits() < target_creep.hits_max() {
+                if creep.pos().is_near_to(target_creep.pos()) {
+                    creep.heal(&target_creep).unwrap_or_else(|e| {
+                        warn!("couldn't heal: {:?}", e);
+                        cancel(creep.try_id().unwrap());
+                    });
+                    complete(creep.try_id().unwrap());
+                } else {
+                    let _ = creep.move_to(&target_creep);
+                }
+            } else {
+                cancel(creep.try_id().unwrap());
+            }
+        } else {
+            cancel(creep.try_id().unwrap());
+        }
+    }
+}

--- a/src/tasks/build.rs
+++ b/src/tasks/build.rs
@@ -1,0 +1,63 @@
+use std::fmt::Debug;
+
+use log::*;
+use screeps::{
+    ConstructionSite, Creep, ErrorCode, HasPosition, MaybeHasTypedId, ObjectId, ResourceType,
+    SharedCreepProperties,
+};
+
+pub struct BuildTask {
+    target: ObjectId<ConstructionSite>,
+}
+
+impl BuildTask {
+    pub fn new(target: ObjectId<ConstructionSite>) -> BuildTask {
+        BuildTask { target }
+    }
+}
+
+impl super::Task for BuildTask {
+    fn execute(
+        &self,
+        creep: &Creep,
+        complete: Box<dyn FnOnce(ObjectId<Creep>)>,
+        cancel: Box<dyn FnOnce(ObjectId<Creep>)>,
+    ) {
+        if creep.store().get_used_capacity(Some(ResourceType::Energy)) == 0 {
+            complete(creep.try_id().unwrap());
+            return;
+        }
+
+        if let Some(construction_site) = self.target.resolve() {
+            creep.build(&construction_site).unwrap_or_else(|e| match e {
+                ErrorCode::NotInRange => {
+                    let _ = creep.move_to(&construction_site);
+                }
+                _ => {
+                    warn!("couldn't build: {:?}", e);
+                    cancel(creep.try_id().unwrap());
+                }
+            });
+        } else {
+            cancel(creep.try_id().unwrap());
+        }
+    }
+}
+
+impl Debug for BuildTask {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        if let Some(construction_site) = self.target.resolve() {
+            write!(
+                f,
+                "Build {:?} at ({}, {}) [{}/{}]",
+                construction_site.structure_type(),
+                construction_site.pos().x().u8(),
+                construction_site.pos().y().u8(),
+                construction_site.progress(),
+                construction_site.progress_total()
+            )
+        } else {
+            write!(f, "Build ({:?})", self.target)
+        }
+    }
+}

--- a/src/tasks/harvest.rs
+++ b/src/tasks/harvest.rs
@@ -1,0 +1,60 @@
+use std::fmt::Debug;
+
+use log::*;
+use screeps::{
+    Creep, HasPosition, MaybeHasTypedId, ObjectId, ResourceType, SharedCreepProperties, Source,
+};
+
+pub struct HarvestTask {
+    target: ObjectId<Source>,
+}
+
+impl HarvestTask {
+    pub fn new(target: ObjectId<Source>) -> HarvestTask {
+        HarvestTask { target }
+    }
+}
+
+impl super::Task for HarvestTask {
+    fn execute(
+        &self,
+        creep: &Creep,
+        complete: Box<dyn FnOnce(ObjectId<Creep>)>,
+        cancel: Box<dyn FnOnce(ObjectId<Creep>)>,
+    ) {
+        if creep.store().get_free_capacity(Some(ResourceType::Energy)) == 0 {
+            complete(creep.try_id().unwrap());
+            return;
+        }
+
+        if let Some(source) = self.target.resolve() {
+            if creep.pos().is_near_to(source.pos()) {
+                creep.harvest(&source).unwrap_or_else(|e| {
+                    warn!("couldn't harvest: {:?}", e);
+                    cancel(creep.try_id().unwrap());
+                });
+            } else {
+                let _ = creep.move_to(&source);
+            }
+        } else {
+            cancel(creep.try_id().unwrap());
+        }
+    }
+}
+
+impl Debug for HarvestTask {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        if let Some(source) = self.target.resolve() {
+            write!(
+                f,
+                "Harvest ({}, {}) [{}/{}]",
+                source.pos().x().u8(),
+                source.pos().y().u8(),
+                source.energy(),
+                source.energy_capacity()
+            )
+        } else {
+            write!(f, "Harvest ({:?})", self.target)
+        }
+    }
+}

--- a/src/tasks/heal.rs
+++ b/src/tasks/heal.rs
@@ -1,0 +1,62 @@
+use std::fmt::Debug;
+
+use log::*;
+use screeps::{Creep, HasPosition, MaybeHasTypedId, ObjectId, ResourceType, SharedCreepProperties};
+
+pub struct HealTask {
+    target: ObjectId<Creep>,
+}
+
+impl HealTask {
+    pub fn new(target: ObjectId<Creep>) -> HealTask {
+        HealTask { target }
+    }
+}
+
+impl super::Task for HealTask {
+    fn execute(
+        &self,
+        creep: &Creep,
+        complete: Box<dyn FnOnce(ObjectId<Creep>)>,
+        cancel: Box<dyn FnOnce(ObjectId<Creep>)>,
+    ) {
+        if creep.store().get_free_capacity(Some(ResourceType::Energy)) == 0 {
+            complete(creep.try_id().unwrap());
+            return;
+        }
+
+        if let Some(target_creep) = self.target.resolve() {
+            if target_creep.hits() < target_creep.hits_max() {
+                if creep.pos().is_near_to(target_creep.pos()) {
+                    creep.heal(&target_creep).unwrap_or_else(|e| {
+                        warn!("couldn't heal: {:?}", e);
+                        cancel(creep.try_id().unwrap());
+                    });
+                } else {
+                    let _ = creep.move_to(&target_creep);
+                }
+            } else {
+                complete(creep.try_id().unwrap());
+            }
+        } else {
+            cancel(creep.try_id().unwrap());
+        }
+    }
+}
+
+impl Debug for HealTask {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        if let Some(target_creep) = self.target.resolve() {
+            write!(
+                f,
+                "Heal ({}, {}) [{}/{}]",
+                target_creep.pos().x().u8(),
+                target_creep.pos().y().u8(),
+                target_creep.hits(),
+                target_creep.hits_max()
+            )
+        } else {
+            write!(f, "Heal ({:?})", self.target)
+        }
+    }
+}

--- a/src/tasks/repair.rs
+++ b/src/tasks/repair.rs
@@ -1,0 +1,65 @@
+use std::fmt::Debug;
+
+use log::*;
+use screeps::{
+    Creep, HasPosition, MaybeHasTypedId, ObjectId, ResourceType, SharedCreepProperties, Structure,
+};
+
+pub struct RepairTask {
+    target: ObjectId<Structure>,
+}
+
+impl RepairTask {
+    pub fn new(target: ObjectId<Structure>) -> RepairTask {
+        RepairTask { target }
+    }
+}
+
+impl super::Task for RepairTask {
+    fn execute(
+        &self,
+        creep: &Creep,
+        complete: Box<dyn FnOnce(ObjectId<Creep>)>,
+        cancel: Box<dyn FnOnce(ObjectId<Creep>)>,
+    ) {
+        if creep.store().get_used_capacity(Some(ResourceType::Energy)) == 0 {
+            complete(creep.try_id().unwrap());
+            return;
+        }
+
+        if let Some(structure) = self.target.resolve() {
+            if creep.pos().is_near_to(structure.pos()) {
+                creep.repair(&structure).unwrap_or_else(|e| {
+                    warn!("couldn't repair: {:?}", e);
+                });
+                if structure.hits() >= structure.hits_max()
+                    || creep.store().get_used_capacity(Some(ResourceType::Energy)) == 0
+                {
+                    cancel(creep.try_id().unwrap());
+                }
+            } else {
+                let _ = creep.move_to(&structure);
+            }
+        } else {
+            complete(creep.try_id().unwrap());
+        }
+    }
+}
+
+impl Debug for RepairTask {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        if let Some(structure) = self.target.resolve() {
+            write!(
+                f,
+                "Repair {:?} at ({}, {}) [{}/{}]",
+                structure.structure_type(),
+                structure.pos().x().u8(),
+                structure.pos().y().u8(),
+                structure.hits(),
+                structure.hits_max()
+            )
+        } else {
+            write!(f, "Repair ({:?})", self.target)
+        }
+    }
+}

--- a/src/tasks/transfer.rs
+++ b/src/tasks/transfer.rs
@@ -1,0 +1,61 @@
+use std::fmt::Debug;
+
+use log::*;
+use screeps::{
+    Creep, HasPosition, MaybeHasTypedId, ObjectId, Resolvable, ResourceType, SharedCreepProperties,
+    Transferable,
+};
+
+pub struct TransferTask<T: Transferable + Resolvable> {
+    target: ObjectId<T>,
+}
+
+impl<T: Transferable + Resolvable> TransferTask<T> {
+    pub fn new(target: ObjectId<T>) -> TransferTask<T> {
+        TransferTask { target }
+    }
+}
+
+impl<T: Transferable + Resolvable> super::Task for TransferTask<T> {
+    fn execute(
+        &self,
+        creep: &Creep,
+        complete: Box<dyn FnOnce(ObjectId<Creep>)>,
+        cancel: Box<dyn FnOnce(ObjectId<Creep>)>,
+    ) {
+        if creep.store().get_used_capacity(Some(ResourceType::Energy)) == 0 {
+            complete(creep.try_id().unwrap());
+            return;
+        }
+
+        if let Some(target) = self.target.resolve() {
+            if creep.pos().is_near_to(target.pos()) {
+                creep
+                    .transfer(&target, ResourceType::Energy, None)
+                    .unwrap_or_else(|e| {
+                        warn!("couldn't transfer: {:?}", e);
+                        cancel(creep.try_id().unwrap());
+                    });
+            } else {
+                let _ = creep.move_to(&target);
+            }
+        } else {
+            cancel(creep.try_id().unwrap());
+        }
+    }
+}
+
+impl<T: Transferable + Resolvable> Debug for TransferTask<T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        if let Some(structure) = self.target.resolve() {
+            write!(
+                f,
+                "Transfering energy to ({}, {})",
+                structure.pos().x().u8(),
+                structure.pos().y().u8(),
+            )
+        } else {
+            write!(f, "Transfer ({:?})", self.target)
+        }
+    }
+}

--- a/src/tasks/upgrade.rs
+++ b/src/tasks/upgrade.rs
@@ -1,0 +1,56 @@
+use std::fmt::Debug;
+
+use log::*;
+use screeps::{
+    Creep, ErrorCode, MaybeHasTypedId, ObjectId, ResourceType, SharedCreepProperties,
+    StructureController,
+};
+
+pub struct UpgradeTask {
+    target: ObjectId<StructureController>,
+}
+
+impl UpgradeTask {
+    pub fn new(target: ObjectId<StructureController>) -> UpgradeTask {
+        UpgradeTask { target }
+    }
+}
+
+impl super::Task for UpgradeTask {
+    fn execute(
+        &self,
+        creep: &Creep,
+        complete: Box<dyn FnOnce(ObjectId<Creep>)>,
+        cancel: Box<dyn FnOnce(ObjectId<Creep>)>,
+    ) {
+        if creep.store().get_used_capacity(Some(ResourceType::Energy)) == 0 {
+            complete(creep.try_id().unwrap());
+            return;
+        }
+
+        if let Some(controller) = self.target.resolve() {
+            creep
+                .upgrade_controller(&controller)
+                .unwrap_or_else(|e| match e {
+                    ErrorCode::NotInRange => {
+                        let _ = creep.move_to(&controller);
+                    }
+                    _ => {
+                        warn!("couldn't upgrade: {:?}", e);
+                        cancel(creep.try_id().unwrap());
+                    }
+                });
+        } else {
+            cancel(creep.try_id().unwrap());
+        }
+    }
+}
+
+impl Debug for UpgradeTask {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // f.debug_struct("UpgradeTask")
+        //     .field("target", &self.target)
+        //     .finish()
+        write!(f, "Upgrade({:?})", self.target)
+    }
+}


### PR DESCRIPTION
Separates the original "screep targets" into individual tasks with their own internal modules in a bigger `task` module.

This should help minimize the code within the core library as I add more tasks in the future.